### PR TITLE
Fix #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ A few days ago I found a mod on the Banana Land server which allows you to craft
 
 **Dependencies:** default
 
-**Optional Dependencies:** [mobs_monster](https://github.com/tenplus1/mobs_monster)(note: depends on [mobs](https://forum.minetest.net/viewtopic.php?t=9917)), [lavastuff](https://forum.minetest.net/viewtopic.php?f=9&t=18608), [toolranks](https://forum.minetest.net/viewtopic.php?t=18056)
+**Optional Dependencies:** [mobs_monster](https://github.com/tenplus1/mobs_monster)(note: depends on [mobs](https://forum.minetest.net/viewtopic.php?t=9917)), [lavastuff](https://forum.minetest.net/viewtopic.php?f=9&t=18608), [toolranks](https://forum.minetest.net/viewtopic.php?t=18056), [toolranks_extras](https://github.com/louisroyer/minetest-toolranks-extras)
 
-**Notes on Optional Dependencies:** Adding one of or both of the optional dependencies will add a Lava Multitool which is better than diamond and auto-smelts like the lava pick in mobs_monster. Adding toolranks enables all of the functionality of the toolranks mod.
+**Notes on Optional Dependencies:** Adding one of or both of the optional dependencies will add a Lava Multitool which is better than diamond and auto-smelts like the lava pick in mobs_monster. Adding toolranks enables all of the functionality of the toolranks mod. Adding toolranks extras improves the display of the tool description.
 
 ## Screenshots and Crafting
 

--- a/init.lua
+++ b/init.lua
@@ -1,10 +1,11 @@
 -- Translation support
 local S = minetest.get_translator("multitools")
 local use_toolranks = minetest.get_modpath("toolranks")
+local use_toolranks_extras = minetest.get_modpath("toolranks_extras")
 multitools = {}
 
-if use_toolranks then
-    toolranks.register_extra_tool_type("multitool", S("multitool"))
+if use_toolranks_extras and toolranks_extras.register_tool_type then
+    toolranks_extras.register_tool_type("multitool", S("multitool"))
 end
 
 if minetest.get_modpath("lavastuff") then

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,3 @@
 name = multitools
 depends = default
-optional_depends = toolranks, mobs_monster, lavastuff, ethereal, moreores
+optional_depends = toolranks, mobs_monster, lavastuff, ethereal, moreores, toolranks_extras


### PR DESCRIPTION
Requires at least v1.4.0 of toolranks_extras to display multitool instead of tool in description.
Fixes #4.